### PR TITLE
Fixed Prototype Pollution in materialUI

### DIFF
--- a/packages/material-ui-utils/src/deepmerge.ts
+++ b/packages/material-ui-utils/src/deepmerge.ts
@@ -16,7 +16,7 @@ export default function deepmerge<T>(
   if (isPlainObject(target) && isPlainObject(source)) {
     Object.keys(source).forEach((key) => {
       // Avoid prototype pollution
-      if (key === '__proto__') {
+      if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
         return;
       }
 


### PR DESCRIPTION
### 📊 Metadata *

Prototype Pollution bug

### ⚙️ Description *

materialUI is react components for faster and easier web development. Build your own design system, or start with Material Design.

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.

### 💻 Technical Description *

The bug is fixed by validating the input `key` to check for prototypes. It is implemented by a simple validation to check for prototype keywords `(__proto__, constructor and prototype)`, where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability. 

### 🐛 Proof of Concept (PoC) *

Clone the project, install the required dependencies and on running the below snippet of code, it triggers prototype pollution and logs `true`.
```javascript
var utils = require('@material-ui/utils');
var src = {};
let object = utils.deepmerge({}, JSON.parse('{ "myProperty": "a", "prototype" : { "isAdmin" : true } }'), {
    clone: false,
});
console.log(object.prototype.isAdmin);
```

![image](https://user-images.githubusercontent.com/16708391/94050775-58b00680-fdf4-11ea-9edf-0df753747e3c.png)


### 🔥 Proof of Fix (PoF) *

After the fix is applied, it returns an error since the polluted referred in the PoC is no more accessible(which is intended). Hence fixing the issue.

![image](https://user-images.githubusercontent.com/16708391/94050832-6a91a980-fdf4-11ea-9526-bee82e252f9c.png)



### 👍 User Acceptance Testing (UAT)

Just prevented some keywords as `path` and no breaking changes are introduced. :)
